### PR TITLE
Add gruntserver command

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -199,3 +199,9 @@ WORKBENCH = {
         os.environ.get('WORKBENCH_RESET_STATE_ON_RESTART', "false").lower() == "true"
     )
 }
+
+XBLOCK_DIRECTORY = os.path.join(
+    os.path.sep,
+    'root',
+    'xblocks',
+)

--- a/workbench/management/__init__.py
+++ b/workbench/management/__init__.py
@@ -1,0 +1,3 @@
+"""
+Create a management module
+"""

--- a/workbench/management/commands/__init__.py
+++ b/workbench/management/commands/__init__.py
@@ -1,0 +1,3 @@
+"""
+Create a management.commands module
+"""

--- a/workbench/management/commands/gruntserver.py
+++ b/workbench/management/commands/gruntserver.py
@@ -1,0 +1,78 @@
+"""
+Integrate Grunt into Django with `manage.py gruntserver`
+
+This is meant to replace `manage.py runserver` for Grunt-powered
+projects.
+"""
+import atexit
+import os
+import signal
+import subprocess
+
+from django.conf import settings
+from django.contrib.staticfiles.management.commands import runserver
+
+
+class Command(runserver.Command):
+    """
+    Create the gruntserver command to replace runserver
+    """
+    _grunt_processes = []
+
+    def _start_grunt_processes(self):
+        """
+        Start `grunt watch` for each project in `settings.XBLOCK_DIRECTORY`
+        """
+        self._write('>>> Start grunt')
+        for directory in os.listdir(settings.XBLOCK_DIRECTORY):
+            path_absolute_directory = os.path.join(
+                settings.XBLOCK_DIRECTORY,
+                directory,
+            )
+            path_absolute_file = os.path.join(
+                path_absolute_directory,
+                'Gruntfile.js',
+            )
+            if os.path.isfile(path_absolute_file):
+                process = subprocess.Popen(
+                    [
+                        'grunt watch --gruntfile={0}/Gruntfile.js --base={0}'.format(
+                            path_absolute_directory,
+                        )
+                    ],
+                    shell=True,
+                    stdin=subprocess.PIPE,
+                    stdout=self.stdout,
+                    stderr=self.stderr,
+                )
+                self._grunt_processes.append(process)
+                self._write(
+                    '>>> Fork grunt process, pid={0}: {1}'.format(
+                        unicode(process.pid),
+                        directory,
+                    )
+                )
+                atexit.register(self._kill_grunt_process, process.pid)
+
+    def _kill_grunt_process(self, pid):
+        """
+        Kill the specified Grunt process
+        """
+        self._write('>>> Kill grunt process, pid={0}'.format(
+            unicode(pid),
+        ))
+        os.kill(pid, signal.SIGTERM)
+
+    def _write(self, value):
+        """
+        Write as unicode to STDOUT, appending a newline
+        """
+        self.stdout.write(unicode(value))
+        self.stdout.write(u'\n')
+
+    def inner_run(self, *args, **kwargs):
+        """
+        Handle launching of child processes
+        """
+        self._start_grunt_processes()
+        return super(Command, self).inner_run(*args, **kwargs)

--- a/workbench/test/test_thumbs.py
+++ b/workbench/test/test_thumbs.py
@@ -102,7 +102,7 @@ class ThreeThumbsTest(SeleniumTest):
         down_count_css = 'span.downvote span.count'
 
         # Up vote for the first thumb
-        thumbs[0].find_element_by_css_selector('span.downvote').click()
+        thumbs[0].find_element_by_css_selector(down_count_css).click()
 
         # Only the first thumb's downcount should increase
         self.assertEqual('1', thumbs[0].find_element_by_css_selector(down_count_css).text)


### PR DESCRIPTION
This is to be used in place of `runserver`. In addition to performing
`runserver`'s tasks, it also launches the `grunt watch` listener.
