### PR TITLE
Hide sample xblocks from index page, per ENV var

### DIFF
--- a/workbench/settings.py
+++ b/workbench/settings.py
@@ -11,6 +11,23 @@ DJFS = {'type': 'osfs',
         'url_root': '/static/djpyfs'}
 
 DEBUG = True
+if os.environ.get('EXCLUDE_SAMPLE_XBLOCKS') == 'yes':
+    EXCLUDED_XBLOCKS = {
+        'allscopes_demo',
+        'attempts_scoreboard_demo',
+        'equality_demo',
+        'filethumbs',
+        'helloworld_demo',
+        'html_demo',
+        'problem_demo',
+        'sidebar_demo',
+        'slider_demo',
+        'textinput_demo',
+        'thumbs',
+        'view_counter_demo',
+    }
+else:
+    EXCLUDED_XBLOCKS = set()
 
 TEMPLATES = [
     {

--- a/workbench/views.py
+++ b/workbench/views.py
@@ -10,6 +10,7 @@ import json
 import logging
 import mimetypes
 
+from django.conf import settings
 from django.http import Http404, HttpResponse
 from django.shortcuts import redirect, render_to_response
 from django.views.decorators.csrf import csrf_exempt, ensure_csrf_cookie
@@ -40,6 +41,11 @@ def get_student_id(request):
 def index(_request):
     """Render `index.html`"""
     the_scenarios = sorted(get_scenarios().items())
+    the_scenarios = [
+        (class_name, scenario)
+        for class_name, scenario in the_scenarios
+        if class_name.split('.')[0] not in settings.EXCLUDED_XBLOCKS
+    ]
     return render_to_response('workbench/index.html', {
         'scenarios': [(desc, scenario.description) for desc, scenario in the_scenarios]
     })


### PR DESCRIPTION
This is crucial to our use-case at Stanford, where we spin up a docker
container with_out_ any of the sample xblocks displayed, but then we
extend from this "empty" sdk, install our xblock, and now have a
specialized showcase just for our xblock, plus all the additional
benefits of a read-to-go container that supports all of our xblock work:
- runserver
- tests
- translations
- static file compilation